### PR TITLE
chore(CR-26930): upgrading docker-compose version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG COMPOSE_VERSION=v2.28.1
+ARG COMPOSE_VERSION=v2.32.2
 
 FROM docker/compose-bin:${COMPOSE_VERSION} AS compose
 

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.5.0
+version: 1.5.1

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 2.32.2
+version: 1.5.2

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.5.1
+version: 2.32.2


### PR DESCRIPTION
## What
CVE-2024-45338 fixed by upgrading docker-compose
## Why

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
