### PR TITLE
fix: rebuild image and add sha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM docker/compose-bin:${COMPOSE_VERSION} AS compose-bin
 
 
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-debian-base
-FROM octopusdeploy/dhi-debian-base:trixie-debian13 AS compose-plugin
+FROM octopusdeploy/dhi-debian-base:trixie-debian13@sha256:9ef766670af4743904b0f992a26b525c6c914648b56ea597ec23452adcf1a95d AS compose-plugin
 WORKDIR /home/compose
 COPY --chown=nonroot:nonroot --chmod=755 --from=compose-bin /docker-compose /usr/local/bin/docker-compose
 

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.6.0
+version: 1.6.1


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build


<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. ↓↓↓ ⚠️ -->
## Security Report

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/dev/compose:cr-34338-security@sha256:2bd06ad8fbe8f5bc96b32f5d4b98a5edeeb7972c4acf5f4ebe088db2988317bc](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A2bd06ad8fbe8f5bc96b32f5d4b98a5edeeb7972c4acf5f4ebe088db2988317bc)
>
> **Baseline**:
[quay.io/codefresh/compose:main@sha256:75fb0bbd1d13b0fe2b9e4519bd979a3da56c526ca01ec26f2472f48b7af44311](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A75fb0bbd1d13b0fe2b9e4519bd979a3da56c526ca01ec26f2472f48b7af44311)

> [!IMPORTANT]
> Current summary is in beta mode.
> Please analyze [the full scan report](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A2bd06ad8fbe8f5bc96b32f5d4b98a5edeeb7972c4acf5f4ebe088db2988317bc) for comprehensive details.

### Fixed CVEs: 17
#### 🟣 Critical: 1
- CVE-2025-15467 in `openssl@3.5.4-1~deb13u1` at `unknown path`
#### 🔴 High: 3
- CVE-2025-69421 in `openssl@3.5.4-1~deb13u1` at `unknown path`
- CVE-2025-69420 in `openssl@3.5.4-1~deb13u1` at `unknown path`
- CVE-2025-69419 in `openssl@3.5.4-1~deb13u1` at `unknown path`
#### 🟠 Medium: 8
- CVE-2025-11187 in `openssl@3.5.4-1~deb13u1` at `unknown path`
- CVE-2025-66199 in `openssl@3.5.4-1~deb13u1` at `unknown path`
- CVE-2025-15468 in `openssl@3.5.4-1~deb13u1` at `unknown path`
- CVE-2026-22795 in `openssl@3.5.4-1~deb13u1` at `unknown path`
- CVE-2025-15469 in `openssl@3.5.4-1~deb13u1` at `unknown path`
- CVE-2026-22796 in `openssl@3.5.4-1~deb13u1` at `unknown path`
- CVE-2025-68160 in `openssl@3.5.4-1~deb13u1` at `unknown path`
- CVE-2025-69418 in `openssl@3.5.4-1~deb13u1` at `unknown path`
#### 🟡 Low: 2
- CVE-2025-7709 in `sqlite3@3.46.1-7` at `unknown path`
- CVE-2025-14104 in `util-linux@2.41-5` at `unknown path`
#### ⚪️ Unimportant: 3
- CVE-2022-0563 in `util-linux@2.41-5` at `unknown path`
- CVE-2011-3374 in `apt@3.0.3` at `unknown path`
- CVE-2011-4116 in `perl@5.40.1-6` at `unknown path`

<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. ↑↑↑ ⚠️ -->
