### PR TITLE
build: upgrade base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM docker/compose-bin:${COMPOSE_VERSION} AS compose-bin
 
 
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-debian-base
-FROM octopusdeploy/dhi-debian-base:trixie-debian13@sha256:75eec9a1a76a02ddf88761684efd9a72de6a5ec2c5d1abd002c03a475d5d23b7 AS compose-plugin
+FROM octopusdeploy/dhi-debian-base:trixie-debian13@sha256:79ea7f22d1b7e3f73b0988258b62bcbf73da44f0d82476fbb95d811130168e55 AS compose-plugin
 WORKDIR /home/compose
 COPY --chown=nonroot:nonroot --chmod=755 --from=compose-bin /docker-compose /usr/local/bin/docker-compose
 

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.6.3
+version: 1.6.4


### PR DESCRIPTION
## What

This fixes multiple vulnerabilities.

Relevant tickets:

https://codefresh-io.atlassian.net/browse/CR-37908
https://codefresh-io.atlassian.net/browse/CR-38883
https://codefresh-io.atlassian.net/browse/CR-38884
https://codefresh-io.atlassian.net/browse/CR-38952
https://codefresh-io.atlassian.net/browse/CR-38959
https://codefresh-io.atlassian.net/browse/CR-38980
https://codefresh-io.atlassian.net/browse/CR-39030

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build


<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. ↓↓↓ ⚠️ -->
## Security Report

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/dev/compose:cr-39217@sha256:04c2e086ba959106f931cbd25c677c6da4e51084a047ebd4a39c2eea0ff5e2dc](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A04c2e086ba959106f931cbd25c677c6da4e51084a047ebd4a39c2eea0ff5e2dc)
>
> **Baseline**:
[quay.io/codefresh/compose:main@sha256:2efa1e36e555fab8e7879146c53437bfad2f9b94efec8725341882137c5859e6](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A2efa1e36e555fab8e7879146c53437bfad2f9b94efec8725341882137c5859e6)

> [!IMPORTANT]
> Current summary is in beta mode.
> Please analyze [the full scan report](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A04c2e086ba959106f931cbd25c677c6da4e51084a047ebd4a39c2eea0ff5e2dc) for comprehensive details.

### Fixed CVEs: 7
#### 🟣 Critical: 1
- CVE-2026-31789 in `openssl@3.5.5-1~deb13u1` at `unknown path`
#### 🔴 High: 6
- CVE-2026-28387 in `openssl@3.5.5-1~deb13u1` at `unknown path`
- CVE-2026-31790 in `openssl@3.5.5-1~deb13u1` at `unknown path`
- CVE-2026-28390 in `openssl@3.5.5-1~deb13u1` at `unknown path`
- CVE-2026-28389 in `openssl@3.5.5-1~deb13u1` at `unknown path`
- CVE-2026-28388 in `openssl@3.5.5-1~deb13u1` at `unknown path`
- CVE-2026-2673 in `openssl@3.5.5-1~deb13u1` at `unknown path`


[🔗 View all related Jira tickets](https://codefresh-io.atlassian.net/jira/software/c/projects/CR/issues?jql=project%20%3D%20CR%20AND%20%22security%20image%5Bshort%20text%5D%22%20~%20%22compose%22%20AND%20(%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-31789%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-28387%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-31790%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-28390%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-28389%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-28388%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-2673%22)%20ORDER%20BY%20created%20ASC)

<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. ↑↑↑ ⚠️ -->
