### PR TITLE
fix(security): update dhi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # CI relies on this ARG. Don't remove or rename it
-ARG COMPOSE_VERSION=v5.1.3
+ARG COMPOSE_VERSION=v5.1.4
 FROM docker/compose-bin:${COMPOSE_VERSION} AS compose-bin
 
 
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-debian-base
-FROM octopusdeploy/dhi-debian-base:trixie-debian13@sha256:79ea7f22d1b7e3f73b0988258b62bcbf73da44f0d82476fbb95d811130168e55 AS compose-plugin
+FROM octopusdeploy/dhi-debian-base:trixie-debian13@sha256:436787c2d77ed1ef1cfe3ce5848f3968244d8948463a29094e1e672da9a6fa24 AS compose-plugin
 WORKDIR /home/compose
 COPY --chown=nonroot:nonroot --chmod=755 --from=compose-bin /docker-compose /usr/local/bin/docker-compose
 

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.6.4
+version: 1.6.5


### PR DESCRIPTION
## What

## Why

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build


<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. ↓↓↓ ⚠️ -->
## Security Report

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/dev/compose:cr-37938-security@sha256:96800599f30e74b305fa354a402efc5b8d70fb6b841884282848face368f1c50](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A96800599f30e74b305fa354a402efc5b8d70fb6b841884282848face368f1c50)
>
> **Baseline**:
[quay.io/codefresh/compose:main@sha256:04c2e086ba959106f931cbd25c677c6da4e51084a047ebd4a39c2eea0ff5e2dc](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A04c2e086ba959106f931cbd25c677c6da4e51084a047ebd4a39c2eea0ff5e2dc)

> [!IMPORTANT]
> Current summary is in beta mode.
> Please analyze [the full scan report](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A96800599f30e74b305fa354a402efc5b8d70fb6b841884282848face368f1c50) for comprehensive details.

### Fixed CVEs: 34
#### 🔴 High: 10
- CVE-2026-4437 in `glibc@2.41-12+deb13u2` at `unknown path`
- CVE-2026-4046 in `glibc@2.41-12+deb13u2` at `unknown path`
- CVE-2026-39836 in `net@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-33814 in `net/http@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-33811 in `net@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-32283 in `crypto/tls@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-32281 in `crypto/x509@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-32280 in `crypto/x509@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-4878 in `libcap2@1:2.75-10` at `unknown path`
- CVE-2026-39883 in `go.opentelemetry.io/otel/sdk@v1.42.0` at `/usr/local/bin/docker-compose`
#### 🟠 Medium: 5
- CVE-2026-39826 in `html/template@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-39823 in `html/template@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-32289 in `html/template@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-32288 in `archive/tar@1.25.8` at `/usr/local/bin/docker-compose`
- CVE-2026-4438 in `glibc@2.41-12+deb13u2` at `unknown path`
#### 🟡 Low: 13
- CVE-2026-5450 in `glibc@2.41-12+deb13u2` at `unknown path`
- CVE-2025-69720 in `ncurses@6.5+20250216-2` at `unknown path`
- CVE-2026-5928 in `glibc@2.41-12+deb13u2` at `unknown path`
- CVE-2026-5435 in `glibc@2.41-12+deb13u2` at `unknown path`
- CVE-2026-6238 in `glibc@2.41-12+deb13u2` at `unknown path`
- CVE-2026-5704 in `tar@1.35+dfsg-3.1` at `unknown path`
- CVE-2026-27171 in `zlib@1:1.3.dfsg+really1.3.1-1` at `unknown path`
- CVE-2026-40228 in `systemd@257.9-1~deb13u1` at `unknown path`
- CVE-2026-4105 in `systemd@257.9-1~deb13u1` at `unknown path`
- CVE-2026-40226 in `systemd@257.9-1~deb13u1` at `unknown path`
- CVE-2026-40225 in `systemd@257.9-1~deb13u1` at `unknown path`
- CVE-2026-29111 in `systemd@257.9-1~deb13u1` at `unknown path`
- CVE-2025-6141 in `ncurses@6.5+20250216-2` at `unknown path`
#### ⚪️ Unimportant: 6
- CVE-2018-20796 in `glibc@2.41-12+deb13u2` at `unknown path`
- CVE-2017-18018 in `coreutils@9.7-3` at `unknown path`
- CVE-2025-5278 in `coreutils@9.7-3` at `unknown path`
- CVE-2013-4392 in `systemd@257.9-1~deb13u1` at `unknown path`
- CVE-2010-4756 in `glibc@2.41-12+deb13u2` at `unknown path`
- CVE-2005-2541 in `tar@1.35+dfsg-3.1` at `unknown path`


[🔗 View all related Jira tickets](https://codefresh-io.atlassian.net/jira/software/c/projects/CR/issues?jql=project%20%3D%20CR%20AND%20%22security%20image%5Bshort%20text%5D%22%20~%20%22compose%22%20AND%20(%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-4437%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-4046%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-39836%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-33814%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-33811%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-32283%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-32281%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-32280%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-4878%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-39883%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-39826%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-39823%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-32289%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-32288%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-4438%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-5450%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2025-69720%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-5928%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2018-20796%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-5435%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-6238%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-5704%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-27171%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2017-18018%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-40228%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-4105%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-40226%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-40225%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2026-29111%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2025-6141%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2025-5278%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2013-4392%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2010-4756%22%20OR%20%22security%20cve%5Bshort%20text%5D%22%20~%20%22CVE-2005-2541%22)%20ORDER%20BY%20created%20ASC)

<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. ↑↑↑ ⚠️ -->
