### PR TITLE
feat: update compose-bin and debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM docker/compose-bin:${COMPOSE_VERSION} AS compose-bin
 
 
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-debian-base
-FROM octopusdeploy/dhi-debian-base:trixie-debian13@sha256:sha256:53d4230bf16411bdc7d641665293ec06a0b58f528823f9e48db2929492be2f5c AS compose-plugin
+FROM octopusdeploy/dhi-debian-base:trixie-debian13@sha256:53d4230bf16411bdc7d641665293ec06a0b58f528823f9e48db2929492be2f5c AS compose-plugin
 WORKDIR /home/compose
 COPY --chown=nonroot:nonroot --chmod=755 --from=compose-bin /docker-compose /usr/local/bin/docker-compose
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # CI relies on this ARG. Don't remove or rename it
-ARG COMPOSE_VERSION=v5.1.4
+ARG COMPOSE_VERSION=v5.2.0
 FROM docker/compose-bin:${COMPOSE_VERSION} AS compose-bin
 
 
 # DHI source: https://hub.docker.com/repository/docker/octopusdeploy/dhi-debian-base
-FROM octopusdeploy/dhi-debian-base:trixie-debian13@sha256:e440d0dabdc54675aa9601f0d794c39f549b6178946cfeffd3b5a31da33ec2d3 AS compose-plugin
+FROM octopusdeploy/dhi-debian-base:trixie-debian13@sha256:sha256:53d4230bf16411bdc7d641665293ec06a0b58f528823f9e48db2929492be2f5c AS compose-plugin
 WORKDIR /home/compose
 COPY --chown=nonroot:nonroot --chmod=755 --from=compose-bin /docker-compose /usr/local/bin/docker-compose
 

--- a/service.yaml
+++ b/service.yaml
@@ -1,1 +1,1 @@
-version: 1.6.6
+version: 1.6.7


### PR DESCRIPTION
---

## Bump Docker Compose from v5.1.4 to v5.2.0

### What changed in this release

The headline change is a **new reconciliation algorithm** ([[#13830](https://github.com/docker/compose/pull/13830)](https://github.com/docker/compose/pull/13830)) — the logic that compares observed container state against the desired state has been rewritten. The release notes include an explicit warning from the maintainers:

> *"If you experience any issues with a Compose workload that was previously working, please open an issue."*

Other notable changes:
- **Skip validation when extracting config variables** ([[#13831](https://github.com/docker/compose/pull/13831)](https://github.com/docker/compose/pull/13831)) — changes how config variables are parsed; could affect non-standard variable usage.
- Fix: `env_file required: false` now honoured for missing files ([[#13848](https://github.com/docker/compose/pull/13848)](https://github.com/docker/compose/pull/13848))
- Fix: TTY auto-detection now probes stderr instead of stdout ([[#13837](https://github.com/docker/compose/pull/13837)](https://github.com/docker/compose/pull/13837))
- Dep bumps: Go 1.26.4, buildkit v0.31.0, containerd v2.2.5, compose-go v2.12.1

### Risk assessment

The reconciliation change is the main concern. This service runs with `COMPOSE_COMPATIBILITY=true`, which adds an extra layer of unpredictability — the new algorithm hasn't been widely tested against v1 compatibility mode workloads.

Everything else in the release (provider plugin `rawsetenv`, `compose watch` depends_on fix, publish fixes) doesn't apply to how this image is used.
<!-- ⚠️ ↓↓↓ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/compose~ ↓↓↓ ⚠️ -->

## Security Report — codefresh/compose

> [!NOTE]
> Compared security scans:
>
> **Current image**:
[quay.io/codefresh/dev/compose:cr-40558-security@sha256:655ec785f3692b28e2c93580ff3abcc59053bdef3ebc0eb605b3d083c5d09fc1](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A655ec785f3692b28e2c93580ff3abcc59053bdef3ebc0eb605b3d083c5d09fc1)
>
> **Baseline**:
[quay.io/codefresh/compose:main@sha256:0a22f22964de1dbaddba8ce928c952d3312d8a1b85fedb49f9ef5f2fbd3130cf](https://app.prismacloud.io/compute?computeState=/monitor/vulnerabilities/images/ci?search%3Dsha256%253A0a22f22964de1dbaddba8ce928c952d3312d8a1b85fedb49f9ef5f2fbd3130cf)

### Fixed CVEs: 13
#### 🟣 Critical: 1
- CVE-2026-39834 in `golang.org/x/crypto/ssh@v0.48.0` at `/usr/local/bin/docker-compose`
#### 🔴 High: 5
- CVE-2026-46597 in `golang.org/x/crypto/ssh@v0.48.0` at `/usr/local/bin/docker-compose`
- CVE-2026-53492 in `github.com/containerd/containerd/v2@v2.2.3` at `/usr/local/bin/docker-compose`
- CVE-2026-53489 in `github.com/containerd/containerd/v2@v2.2.3` at `/usr/local/bin/docker-compose`
- CVE-2026-53488 in `github.com/containerd/containerd/v2@v2.2.3` at `/usr/local/bin/docker-compose`
- CVE-2026-46680 in `github.com/containerd/containerd/v2@v2.2.3` at `/usr/local/bin/docker-compose`
#### 🟠 Medium: 5
- CVE-2026-39882 in `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.42.0` at `/usr/local/bin/docker-compose`
- CVE-2026-39882 in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.42.0` at `/usr/local/bin/docker-compose`
- GO-2026-5547 in `github.com/in-toto/in-toto-golang@v0.10.0` at `/usr/local/bin/docker-compose`
- CVE-2026-50195 in `github.com/containerd/containerd/v2@v2.2.3` at `/usr/local/bin/docker-compose`
- CVE-2026-47262 in `github.com/containerd/containerd/v2@v2.2.3` at `/usr/local/bin/docker-compose`
#### ⚫ Unassigned: 2
- CVE-2026-27145 in `crypto/x509@1.26.3` at `/usr/local/bin/docker-compose`
- CVE-2026-42507 in `net/textproto@1.26.3` at `/usr/local/bin/docker-compose`

### Fixed issues: 5
<!-- Fixed issues: ~[{"identifier":"CFS-13351","dueDate":"2026-08-20"},{"identifier":"CFS-13337","dueDate":"2026-07-21"},{"identifier":"CFS-13325","dueDate":"2026-07-21"},{"identifier":"CFS-13308","dueDate":"2026-08-20"},{"identifier":"CFS-13307","dueDate":"2026-07-21"}]~ -->
- Fixes [CFS-13351](https://linear.app/octopus/issue/CFS-13351/security-or-codefreshcompose-or-cve-2026-47262-or)
- Fixes [CFS-13337](https://linear.app/octopus/issue/CFS-13337/security-or-codefreshcompose-or-cve-2026-53489-or)
- Fixes [CFS-13325](https://linear.app/octopus/issue/CFS-13325/security-or-codefreshcompose-or-cve-2026-53488-or)
- Fixes [CFS-13308](https://linear.app/octopus/issue/CFS-13308/security-or-codefreshcompose-or-cve-2026-50195-or)
- Fixes [CFS-13307](https://linear.app/octopus/issue/CFS-13307/security-or-codefreshcompose-or-cve-2026-53492-or)

<!-- ⚠️ ↑↑↑ Auto-generated by Codefresh CI. Any edits may be overridden. Image: ~codefresh/compose~ ↑↑↑ ⚠️ -->
